### PR TITLE
Add types to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
       "url": "https://github.com/valeriansaliou/node-sonic-channel/blob/master/LICENSE"
     }
   ],
-  "main": "lib/sonic_channel",
+  "main": "./lib/sonic_channel.js",
+  "types": "./lib/sonic_channel.d.ts",
   "engines": {
     "node": ">= 6.0.0"
   },


### PR DESCRIPTION
To allow proper Typescript support an entry `.d.ts` file has to be listed in the `package.json` as the `types` property.